### PR TITLE
Fixes docs build

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -35,26 +35,20 @@ author = "Pedro Camargo"
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    "nbsphinx",
     "sphinx.ext.autodoc",
-    "sphinx_gallery.load_style",
     "sphinx_gallery.gen_gallery",
     "sphinx.ext.intersphinx",
     "sphinx.ext.coverage",
     "sphinx.ext.mathjax",
-    "sphinx_autodoc_annotation",
     "sphinx.ext.autosummary",
     "sphinx.ext.githubpages",
-    "myst_parser",
-    "sphinxcontrib.youtube",
 ]
 
-myst_enable_extensions = ["html_admonition", "colon_fence"]
+# myst_enable_extensions = ["html_admonition", "colon_fence"]
 
 sphinx_gallery_conf = {
-    "examples_dirs": ["examples"],  # path to your example scripts
-    "gallery_dirs": ["_auto_examples"],  # path to where to save gallery generated output
-    "image_scrapers": ("matplotlib"),
+    "examples_dirs": "examples",  # path to your example scripts
+    "gallery_dirs": "_auto_examples",  # path to where to save gallery generated output
     "capture_repr": ("_repr_html_", "__repr__"),
     "remove_config_comments": True,
 }
@@ -62,7 +56,7 @@ sphinx_gallery_conf = {
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
 #
-source_suffix = [".rst", ".md"]
+source_suffix = [".rst"]
 
 # The master toctree document.
 master_doc = "index"

--- a/docs/source/examples/plot_general_example.py
+++ b/docs/source/examples/plot_general_example.py
@@ -1,5 +1,5 @@
 """
-.. _example_matching_aequilibrae_model:
+.. _example_matching_generic_model:
 
 Matching with a generic network
 ==================================

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -33,6 +33,7 @@ Check out other sections in our documentation!
    api
 
 .. _citation:
+
 Citing
 ------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,20 +37,13 @@ auxiliary = ['folium', 'notebook']
 docs = ["pyaml",
         "enum34>=1.1.6",
         "Sphinx",
-        "pydata-sphinx-theme==0.13.3",
-        "sphinx-book-theme",
-        "myst-parser",
-        "sphinx_autodoc_annotation",
-        "nbsphinx",
+        "pydata-sphinx-theme",
         "pillow",
         "matplotlib",
         "folium",
         "sphinx-gallery",
-        "nbsphinx",
         "ipython_genutils",
-        "folium",
-        "ipykernel",
-        "sphinxcontrib-youtube"]
+        "folium"]
 dev = ['mapmatcher[testing, auxiliary, build, docs]']
 
 [project.urls]


### PR DESCRIPTION
In this PR we fix the documentation build.

We
* Removed unused dependencies in TOML and _docs/conf.py_
* Renamed duplicated reference to _docs/source/examples/plot_general_example.py_